### PR TITLE
removed the redundant express import from the user router

### DIFF
--- a/back-end/routes/users.js
+++ b/back-end/routes/users.js
@@ -5,7 +5,6 @@ const bcrypt = require('bcryptjs');
 
 const { authRoute } = require("../util/session_util");
 const { User } = require("../models");
-const e = require('express');
 
 router.get("/", authRoute, async (req, res) => {
   const userId = req.headers.auth_token.split(":")[0];


### PR DESCRIPTION
It was just one line in the users.js file of routes. `const e = require('express');` was never used.